### PR TITLE
refactor: Simplify filter to use new pass_build_env API

### DIFF
--- a/src/sphinxnotes/project/sphinxnotes_render_ext.py
+++ b/src/sphinxnotes/project/sphinxnotes_render_ext.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from sphinx.application import Sphinx
     from sphinx.config import Config
-    from sphinx.environment import BuildEnvironment
 
 
 def _fmt_type(t) -> str:
@@ -47,11 +46,8 @@ def _format_autoconfval_types(valid_types) -> list[str]:
 
 
 @filter('autoconfval_types')
-def autoconfval_types(_: BuildEnvironment):
-    def _filter(valid_types) -> Iterable[str]:
-        return _format_autoconfval_types(valid_types)
-
-    return _filter
+def autoconfval_types(valid_types) -> Iterable[str]:
+    return _format_autoconfval_types(valid_types)
 
 
 DATA_DEFINE_DIRECTIVES = {


### PR DESCRIPTION
## Summary

- Update `autoconfval_types` filter to use the simplified `@filter` decorator
- Remove factory function pattern in favor of single-layer function

## Changes

- Simplified `autoconfval_types` filter in `sphinxnotes_render_ext.py`
- Removed unused `BuildEnvironment` import

## Related

Depends on https://github.com/sphinx-notes/render/pull/23